### PR TITLE
Fix announcement staggering

### DIFF
--- a/dist/theme.scss
+++ b/dist/theme.scss
@@ -349,10 +349,6 @@ $font-size-18: 1.15rem;
     .content {
       font-size: 13px;
 
-      div:last-of-type p {
-        margin-bottom: 0;
-      }
-
       span {
         width: 1.25rem;
         display: inline-block;

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -236,8 +236,6 @@
     color: #005993; }
   #announcements-container .announcement .content {
     font-size: 13px; }
-    #announcements-container .announcement .content div:last-of-type p {
-      margin-bottom: 0; }
     #announcements-container .announcement .content span {
       width: 1.25rem;
       display: inline-block; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucirvine/eeeplus-theme",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "license": "SEE LICENSE IN LICENSE",
   "private": false,
   "scripts": {

--- a/src/announcements.scss
+++ b/src/announcements.scss
@@ -1,3 +1,4 @@
+//TODO: Remove whitespace at bottom of announcements (https://jira.oit.uci.edu/browse/AWTDEV-5045)
 #announcements-container {
   .announcement {
     background-color: white;
@@ -9,10 +10,6 @@
 
     .content {
       font-size: 13px;
-
-      div:last-of-type p {
-        margin-bottom: 0;
-      }
 
       span {
         width: 1.25rem;


### PR DESCRIPTION
Styling that was added to remove whitespace at the bottom of announcements introduced a bug where the announcements are staggering underneath each other. Removing in favor of https://jira.oit.uci.edu/browse/AWTDEV-5045